### PR TITLE
[userdata] Add userdata command to execute EC2 userdata with IMDSv2

### DIFF
--- a/src/config/cloud/aws.ipxe
+++ b/src/config/cloud/aws.ipxe
@@ -19,6 +19,6 @@ exit
 
 :dhcp_ok
 route ||
-chain -ar http://169.254.169.254/latest/user-data ||
+userdata ||
 ifstat ||
 exit

--- a/src/config/cloud/general.h
+++ b/src/config/cloud/general.h
@@ -7,6 +7,11 @@
  */
 #define HTTP_HACK_GCE
 
+/* Allow retrieval of metadata (such as an iPXE boot script) from
+ * AWS Instance Metadata Service Version 2 (IMDSv2).
+ */
+#define HTTP_HACK_EC2
+
 /* Allow scripts to handle errors by powering down the VM to avoid
  * incurring unnecessary costs.
  */

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -311,6 +311,9 @@ REQUIRE_OBJECT ( usb_cmd );
 #ifdef FDT_CMD
 REQUIRE_OBJECT ( fdt_cmd );
 #endif
+#ifdef USERDATA_CMD
+REQUIRE_OBJECT ( userdata_cmd );
+#endif
 
 /*
  * Drag in miscellaneous objects

--- a/src/config/config_http.c
+++ b/src/config/config_http.c
@@ -49,3 +49,6 @@ REQUIRE_OBJECT ( peerdist );
 #ifdef HTTP_HACK_GCE
 REQUIRE_OBJECT ( httpgce );
 #endif
+#ifdef HTTP_HACK_EC2
+REQUIRE_OBJECT ( httpec2 );
+#endif

--- a/src/config/general.h
+++ b/src/config/general.h
@@ -82,6 +82,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 //#define HTTP_AUTH_NTLM	/* NTLM authentication */
 //#define HTTP_ENC_PEERDIST	/* PeerDist content encoding */
 //#define HTTP_HACK_GCE		/* Google Compute Engine hacks */
+//#define HTTP_HACK_EC2		/* Amazon Elastic Compute Cloud hacks */
 
 /*
  * 802.11 cryptosystems and handshaking protocols
@@ -174,6 +175,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define SHIM_CMD		/* EFI shim command (or dummy command) */
 //#define USB_CMD		/* USB commands */
 //#define FDT_CMD		/* Flattened Device Tree commands */
+#define USERDATA_CMD		/* USERDATA command */
 
 /*
  * Certificate sources

--- a/src/core/uri.c
+++ b/src/core/uri.c
@@ -269,6 +269,10 @@ static void uri_dump ( const struct uri *uri ) {
 		DBGC ( uri, " efragment \"%s\"", uri->efragment );
 	if ( uri->params )
 		DBGC ( uri, " params \"%s\"", uri->params->name );
+	if ( uri->aws_token )
+		DBGC ( uri, " aws_token \"%s\"", uri->aws_token );
+	if ( uri->aws_token_ttl )
+		DBGC ( uri, " aws_token_ttl \"%s\"", uri->aws_token_ttl );
 }
 
 /**

--- a/src/hci/commands/userdata_cmd.c
+++ b/src/hci/commands/userdata_cmd.c
@@ -1,0 +1,91 @@
+#include <errno.h>
+#include <getopt.h>
+#include <ipxe/command.h>
+#include <ipxe/http.h>
+#include <ipxe/parseopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <usr/userdata.h>
+
+/** @file
+ *
+ * userdata commands
+ *
+ */
+
+/** "userdata" options */
+struct userdata_options {
+	/** Use the ipv4 IMDS address **/
+	int ipv4;
+	/** Use the ipv6 IMDS address **/
+	int ipv6;
+};
+
+/** "userdata" option list */
+static struct option_descriptor userdata_opts[] = {
+	OPTION_DESC ( "ipv4", '4', no_argument,
+				  struct userdata_options, ipv4, parse_flag ),
+	OPTION_DESC ( "ipv6", '6', no_argument,
+				  struct userdata_options, ipv6, parse_flag ) };
+
+/** "userdata" command descriptor */
+static struct command_descriptor userdata_cmd =
+	COMMAND_DESC ( struct userdata_options, userdata_opts, 0, 0, NULL );
+
+/**
+ * Execute userdata command from command line
+ *
+ * @v argc         Argument count
+ * @v argv         Argument list
+ * @ret rc         Return status code
+ */
+static int userdata_exec ( int argc, char **argv ) {
+	struct userdata_options opts;
+	struct image *image;
+	int rc;
+
+	/* Parse options */
+	rc = parse_options ( argc, argv, &userdata_cmd, &opts );
+	if ( rc != 0 )
+		goto err_parse_options;
+
+	/* Check for invalid flag combination */
+	if ( opts.ipv4 && opts.ipv6 ) {
+		printf ( "Error: Cannot specify both IPv4 and IPv6 flags\n" );
+		rc = -EINVAL;
+		goto err_parse_options;
+	}
+
+	/* Get user data based on IP version preference */
+	if ( opts.ipv4 || opts.ipv6 ) {
+		rc = get_userdata ( opts.ipv6, &image );
+	} else {
+		/* If no IP version is specified, try IPv4 first, then fall back to IPv6 */
+		rc = get_userdata ( 0, &image );
+		if ( rc != 0 ) {
+			rc = get_userdata ( 1, &image );
+		}
+	}
+
+	if ( rc != 0 ) {
+		goto err_userdata;
+	}
+
+	/* Execute user data */
+	rc = execute_userdata ( image );
+	if ( rc != 0 )
+		goto err_userdata;
+
+err_userdata:
+	image_put ( image );
+err_parse_options:
+	return rc;
+}
+
+/** userdata command */
+struct command userdata_command __command = {
+	.name = "userdata",
+	.exec = userdata_exec,
+};

--- a/src/include/ipxe/errfile.h
+++ b/src/include/ipxe/errfile.h
@@ -440,6 +440,9 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define ERRFILE_weierstrass	      ( ERRFILE_OTHER | 0x00660000 )
 #define ERRFILE_efi_cacert	      ( ERRFILE_OTHER | 0x00670000 )
 
+#define ERRFILE_userdata_cmd ( ERRFILE_OTHER | 0x01000000 )
+#define ERRFILE_userdata     ( ERRFILE_OTHER | 0x01010000 )
+#define ERRFILE_imdsv2       ( ERRFILE_OTHER | 0x01030000 )
 /** @} */
 
 #endif /* _IPXE_ERRFILE_H */

--- a/src/include/ipxe/http.h
+++ b/src/include/ipxe/http.h
@@ -104,6 +104,7 @@ struct http_method {
 extern struct http_method http_head;
 extern struct http_method http_get;
 extern struct http_method http_post;
+extern struct http_method http_put;
 
 /******************************************************************************
  *

--- a/src/include/ipxe/uri.h
+++ b/src/include/ipxe/uri.h
@@ -13,6 +13,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #include <stdlib.h>
 #include <ipxe/refcnt.h>
 #include <ipxe/in.h>
+#include <ipxe/http.h>
 
 struct parameters;
 
@@ -86,7 +87,22 @@ struct uri {
 	const char *efragment;
 	/** Request parameters */
 	struct parameters *params;
+	/** HTTP method */
+	struct http_method *method;
+	/** AWS token */
+	char *aws_token;
+	/** AWS token ttl */
+	char *aws_token_ttl;
 } __attribute__ (( packed ));
+
+/** Default TTL (Time To Live) value for AWS tokens in seconds */
+#define AWS_TOKEN_TTL "21600"
+
+/** Length of the AWS token TTL string */
+#define AWS_TOKEN_TTL_LEN 5
+
+/** Maximum length allowed for AWS token string */
+#define MAX_AWS_TOKEN_LEN 64
 
 /**
  * Access URI field

--- a/src/include/usr/imdsv2.h
+++ b/src/include/usr/imdsv2.h
@@ -1,0 +1,19 @@
+#ifndef _USR_IMDSV2_H
+#define _USR_IMDSV2_H
+
+/** @file
+ *
+ * AWS Instance Metadata Service (IMDSv2) helper commands
+ *
+ */
+
+extern int url_concat ( const char *base_url, const char *path, char **url );
+extern int get_imdsv2_token ( char **token, const char *base_url );
+extern int get_imdsv2_metadata ( char *token, const char *base_url, char *metadata_path, char **response );
+extern int get_imds_metadata_base_url ( int use_ipv6, const char **base_url );
+extern int parse_imdsv2_credentials_response ( char *credentials, char *key, char **parsed_val );
+
+#define IMDSV2_IPV4_METADATA_BASE_URL "http://169.254.169.254/latest/"
+#define IMDSV2_IPV6_METADATA_BASE_URL "http://[fd00:ec2::254]/latest/"
+
+#endif /* _USR_IMDSV2_H */

--- a/src/include/usr/userdata.h
+++ b/src/include/usr/userdata.h
@@ -1,0 +1,15 @@
+#ifndef _USR_USERDATA_H
+#define _USR_USERDATA_H
+
+/** @file
+ *
+ * Userdata
+ *
+ */
+
+#include <ipxe/image.h>
+
+extern int get_userdata ( int use_ipv6, struct image **image );
+extern int execute_userdata ( struct image *image );
+
+#endif /* _USR_USERDATA_H */

--- a/src/net/tcp/httpec2.c
+++ b/src/net/tcp/httpec2.c
@@ -1,0 +1,76 @@
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/**
+ * @file
+ *
+ * Amazon Elastic Compute Cloud (EC2) Instance Metadata Service (IMDSv2) retrieval
+ *
+ * IMDSv2 enhances IMDSv1 security by requiring a session token for metadata requests.
+ * This token is obtained via a PUT request to the IMDS endpoint. Subsequent metadata
+ * requests must include this token in the non-standard HTTP header
+ * "X-aws-ec2-metadata-token". Additionally, the "X-aws-ec2-metadata-token-ttl-seconds"
+ * header is required to specify the token's time-to-live.
+ */
+
+#include <ipxe/http.h>
+#include <ipxe/uri.h>
+#include <ipxe/vsprintf.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * Construct HTTP "X-aws-ec2-metadata-token-ttl-seconds" header
+ *
+ * @v http		HTTP transaction
+ * @v buf		Buffer
+ * @v len		Length of buffer
+ * @ret len		Length of header value, or negative error
+ */
+static int http_format_aws_token_ttl ( struct http_transaction *http,
+									   char *buf, size_t len ) {
+	/* Return zero length if no token ttl available */
+	if ( ! http->uri->aws_token_ttl )
+		return 0;
+
+	/* Return required length if no buffer provided */
+	if ( ! buf )
+		return strnlen ( http->uri->aws_token_ttl, AWS_TOKEN_TTL_LEN );
+
+	/* Format the header value */
+	return ssnprintf ( buf, len, "%s", http->uri->aws_token_ttl );
+}
+
+/**
+ * Construct HTTP "X-aws-ec2-metadata-token" header
+ *
+ * @v http		HTTP transaction
+ * @v buf		Buffer
+ * @v len		Length of buffer
+ * @ret len		Length of header value, or negative error
+ */
+static int http_format_aws_token ( struct http_transaction *http,
+								   char *buf, size_t len ) {
+	/* Return zero length if no token available */
+	if ( ! http->uri->aws_token )
+		return 0;
+
+	/* Return required length if no buffer provided */
+	if ( ! buf )
+		return strnlen ( http->uri->aws_token, MAX_AWS_TOKEN_LEN );
+
+	/* Format the header value */
+	return ssnprintf ( buf, len, "%s", http->uri->aws_token );
+}
+
+/** HTTP "X-aws-ec2-metadata-token-ttl-seconds" header */
+struct http_request_header http_request_aws_token_ttl __http_request_header = {
+	.name = "X-aws-ec2-metadata-token-ttl-seconds",
+	.format = http_format_aws_token_ttl,
+};
+
+/** HTTP "X-aws-ec2-metadata-token" header */
+struct http_request_header http_request_aws_token __http_request_header = {
+	.name = "X-aws-ec2-metadata-token",
+	.format = http_format_aws_token,
+};

--- a/src/usr/imdsv2.c
+++ b/src/usr/imdsv2.c
@@ -1,0 +1,276 @@
+#include <errno.h>
+#include <ipxe/image.h>
+#include <ipxe/malloc.h>
+#include <ipxe/uri.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <usr/imdsv2.h>
+#include <usr/imgmgmt.h>
+#include <usr/userdata.h>
+
+/**
+ * Concatenates two URL parts, handling potential slash issues.
+ *
+ * @v base_url      The base URL string.
+ * @v path          The path URL string to append.
+ * @v url			Pointer to a char pointer that will receive the allocated concatenated URL string
+ * @ret rc			Return status code
+ */
+int url_concat ( const char *base_url, const char *path, char **url ) {
+	if ( ! base_url || ! path ) {
+		return -EINVAL;
+	}
+
+	size_t base_len = strlen ( base_url );
+	size_t path_len = strlen ( path );
+	/* total_len has + 2 for the null terminator plus a potential '/' */
+	size_t total_len = base_len + path_len + 2;
+
+	char *result = malloc ( total_len );
+	if ( ! result ) {
+		return -ENOMEM;
+	}
+
+	strcpy ( result, base_url );
+
+	bool base_ends_slash = base_len > 0 && base_url[base_len - 1] == '/';
+	bool path_starts_slash = path_len > 0 && path[0] == '/';
+
+	if ( path_len > 0 ) {
+		if ( ! base_ends_slash && ! path_starts_slash ) {
+			/* Add a '/' inbetween the base url and the path */
+			strcat ( result, "/" );
+		} else if ( base_ends_slash && path_starts_slash ) {
+			/* Remove a '/' fromn the base url */
+			result[base_len - 1] = '\0';
+		}
+		strcat ( result, path );
+	}
+
+	*url = result;
+
+	return 0;
+}
+
+/**
+ * Parses a specific credential value from an IMDSv2 credentials response.
+ *
+ * This function extracts the value associated with a given key from a JSON-formatted
+ * credentials response obtained from IMDSv2. It is NOT a general-purpose JSON parser.
+ *
+ * @v credentials	The JSON-formatted credentials response string.
+ * @v key			The key for the credential value to extract.
+ * @v parsed_val	Pointer to the extracted value (newly allocated). Unmodified on error.
+ * @ret rc			Return status code
+ *
+ * The caller is responsible for freeing the memory allocated for the returned string.
+ */
+int parse_imdsv2_credentials_response ( char *credentials, char *key, char **parsed_val ) {
+	/* +3 for quotes and null terminator */
+	char key_with_quotes[strlen ( key ) + 3];
+	snprintf ( key_with_quotes, sizeof ( key_with_quotes ), "\"%s\"", key );
+
+	/* Find the key */
+	const char *key_start = strstr ( credentials, key_with_quotes );
+	if ( ! key_start ) {
+		return -1;
+	}
+
+	/* Find the colon, skipping whitespace */
+	const char *colon = strchr ( key_start + strlen ( key_with_quotes ), ':' );
+	if ( ! colon ) {
+		return -1;
+	}
+
+	/* Find the opening quote, skipping whitespace */
+	const char *quote = strchr ( ++colon, '"' );
+	if ( ! quote ) {
+		return -1;
+	}
+
+	/* Value starts immediately after the opening quote */
+	const char *value_start = ++quote;
+
+	const char *value_end = strchr ( value_start, '"' );
+
+	const size_t value_length = value_end - value_start;
+	const size_t value_buffer_size = value_length + 1;
+
+	char *value = ( char * ) malloc ( value_buffer_size );
+	if ( ! value ) {
+		return -ENOMEM;
+	}
+
+	/* Fill the memory location with /0's */
+	memset ( value, 0, sizeof ( char ) * value_buffer_size );
+
+	strncpy ( value, value_start, value_length );
+
+	*parsed_val = value;
+
+	return 0;
+}
+
+/**
+ * Copy image data to a buffer
+ *
+ * @v image		Image to read
+ * @v buffer 	Buffer to fill in
+ * @ret rc      Return status code
+ */
+int get_image_data ( struct image *image, char **buffer ) {
+	size_t offset = 0;
+
+	/* Allocate a buffer to hold the data */
+	*buffer = malloc ( image->len + 1 );
+	if ( ! *buffer ) {
+		return -ENOMEM;
+	}
+
+	/* Copy data from userptr_t to our local buffer */
+	memcpy ( *buffer, ( image->data + offset ), image->len );
+
+	/* Null terminate the buffer */
+	( *buffer )[image->len] = '\0';
+
+	return 0;
+}
+
+/**
+ * Get IMDSv2 session token
+ *
+ * @v token           Pointer to store the token string
+ * @v base_url   The AWS IMDS ipv4 or ipv6 base url
+ * @ret rc            Return status code
+ */
+int get_imdsv2_token ( char **token, const char *base_url ) {
+	char *uri_string = NULL;
+	struct uri *uri = NULL;
+	;
+	struct image *image = NULL;
+	int rc;
+
+	/* Build IMDSv2 api token URI */
+	rc = url_concat ( base_url, "api/token", &uri_string );
+	if ( rc != 0 ) {
+		goto err_url_concat;
+	}
+
+	/* Initialize token to NULL */
+	*token = NULL;
+
+	/* Parse the URI string */
+	uri = parse_uri ( uri_string );
+	if ( ! uri ) {
+		rc = -ENOMEM;
+		goto err_uri;
+	}
+
+	/* Set the HTTP method */
+	uri->method = &http_put;
+	/* Set aws token ttl */
+	uri->aws_token_ttl = AWS_TOKEN_TTL;
+
+	/* Get token and store it in an image */
+	rc = imgdownload ( uri, 0, &image );
+	if ( rc != 0 )
+		goto err_token_download;
+
+	/* Get the image data as string */
+	rc = get_image_data ( image, token );
+	if ( rc != 0 )
+		goto err_token_read;
+
+	free ( uri );
+	free ( image );
+	free ( uri_string );
+	return 0;
+err_token_read:
+	image_put ( image );
+err_token_download:
+	uri_put ( uri );
+err_uri:
+err_url_concat:
+	free ( uri_string );
+	return rc;
+}
+
+/**
+ * Get metadata associated with an EC2 Instance using IMDSv2.
+ *
+ * @v token         The AWS IMDSv2 session token to include in the request header.
+ * @v base_url   	The AWS IMDS ipv4 or ipv6 base url
+ * @v metadata_path The specific metadata path to retrieve (e.g., "instance-id").
+ * @v response      A pointer to a character pointer that will store the retrieved metadata string.
+ */
+int get_imdsv2_metadata ( char *token, const char *base_url, char *metadata_path, char **response ) {
+	char *uri_string = NULL;
+	struct uri *uri = NULL;
+	struct image *image = NULL;
+	int rc;
+
+	/* Build IMDSv2 metadata URI */
+	rc = url_concat ( base_url, metadata_path, &uri_string );
+	if ( rc != 0 ) {
+		goto err_url_concat;
+	}
+
+	/* Initialize reponse to NULL */
+	*response = NULL;
+
+	/* Parse the URI string */
+	uri = parse_uri ( uri_string );
+	if ( ! uri ) {
+		rc = -ENOMEM;
+		goto err_uri;
+	}
+
+	/* Set the HTTP method */
+	uri->method = &http_get;
+	/* Set AWS IMDSv2 token */
+	uri->aws_token = token;
+
+	/* Get response and store it in an image */
+	rc = imgdownload ( uri, 0, &image );
+	if ( rc != 0 )
+		goto err_metadata_download;
+
+	/* Get the image data as string */
+	rc = get_image_data ( image, response );
+	if ( rc != 0 )
+		goto err_metadata_read;
+
+	free ( uri );
+	free ( image );
+	free ( uri_string );
+	return 0;
+err_metadata_read:
+	image_put ( image );
+err_metadata_download:
+	uri_put ( uri );
+err_uri:
+err_url_concat:
+	free ( uri_string );
+	return rc;
+}
+
+/**
+ * Sets the appropriate IMDS base URL based on IP version preference.
+ *
+ * @v use_ipv6   Boolean flag to determine whether to use IPv6 (true) or IPv4 (false)
+ * @v base_url   Pointer to a char pointer that will store the selected base URL
+ *              Will be set to either IMDSV2_IPV6_METADATA_BASE_URL or IMDSV2_IPV4_METADATA_BASE_URL
+ *
+ * @ret rc      Return status code
+ */
+int get_imds_metadata_base_url ( int use_ipv6, const char **base_url ) {
+	if ( use_ipv6 ) {
+		*base_url = IMDSV2_IPV6_METADATA_BASE_URL;
+	} else {
+		*base_url = IMDSV2_IPV4_METADATA_BASE_URL;
+	}
+	return 0;
+}

--- a/src/usr/userdata.c
+++ b/src/usr/userdata.c
@@ -1,0 +1,85 @@
+#include <errno.h>
+#include <ipxe/image.h>
+#include <ipxe/malloc.h>
+#include <ipxe/uri.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <usr/imdsv2.h>
+#include <usr/imgmgmt.h>
+#include <usr/userdata.h>
+
+/**
+ * Get user data and store it in an image
+ *
+ * @v use_ipv6   Boolean flag to determine whether to use IPv6 (true) or IPv4 (false)
+ * @v image		Image to fill in
+ * @ret rc		Return status code
+ */
+int get_userdata ( int use_ipv6, struct image **image ) {
+	char *uri_string = NULL;
+	struct uri *uri;
+	const char *base_url;
+	char *token = NULL;
+	int rc;
+
+	rc = get_imds_metadata_base_url ( use_ipv6, &base_url );
+	if ( rc != 0 )
+		goto err_base_url;
+
+	/* Get IMDSv2 session token */
+	rc = get_imdsv2_token ( &token, base_url );
+	if ( rc != 0 )
+		goto err_token;
+
+	/* Build IMDSv2 user data URI */
+	rc = url_concat ( base_url, "user-data", &uri_string );
+	if ( rc != 0 ) {
+		goto err_url_concat;
+	}
+
+	/* Parse the URI string */
+	uri = parse_uri ( uri_string );
+	if ( ! uri ) {
+		rc = -ENOMEM;
+		goto err_uri;
+	}
+
+	/* Set the HTTP method */
+	uri->method = &http_get;
+	/* Set AWS IMDSv2 token */
+	uri->aws_token = token;
+
+	/* Get user data and store it in an image */
+	rc = imgdownload ( uri, 0, image );
+	if ( rc != 0 )
+		goto err_userdata;
+
+	free ( uri );
+	free ( uri_string );
+	return 0;
+err_userdata:
+	uri_put ( uri );
+err_uri:
+err_url_concat:
+	free ( uri_string );
+err_token:
+	free ( token );
+err_base_url:
+	return rc;
+}
+
+/**
+ * Execute user data stored in an image
+ *
+ * @v image		Executable image
+ * @ret rc		Return status code
+ */
+int execute_userdata ( struct image *image ) {
+	int rc;
+	if ( ( rc = image_exec ( image ) ) != 0 )
+		return rc;
+
+	return 0;
+}


### PR DESCRIPTION
This commit introduces a new command which fetches and executes AWS EC2 userdata using IMDSv2. Before this commit, iPXE was not compatible with IMDSv2 which requires a token in the header to fetch the user data. To fetch the token, a PUT request needs to be sent to IMDS. The token is then used in the header of the subsequent GET request to fetch the userdata. This required modifications to the httpcore.c file to add support for PUT requests and for the necessary headers.