### PR TITLE
[userdata] Fix missing script_size calculation in extract_ipxe_script

### DIFF
--- a/src/usr/userdata.c
+++ b/src/usr/userdata.c
@@ -302,6 +302,7 @@ int extract_ipxe_script ( struct image *image ) {
 
 	/* Clean the old data in image and update with the extracted iPXE script */
 	free ( ( void * ) image->data );
+	size_t script_size = strnlen ( ipxe_script, MAX_IPXE_SCRIPT_LEN ) + 1;
 	memcpy ( ( void * ) image->data, ipxe_script, script_size );
 	image->len = script_size;
 	image->type = NULL;


### PR DESCRIPTION
This commit fixes a compilation error in the `extract_ipxe_script` function by adding a missing line that was omitted in the previous commit.

**Problem**: The script_size variable was being used in the `memcpy` call without being declared or calculated, which would cause a compilation error.

**Solution**: Added the missing line that calculates `script_size` using `strnlen(ipxe_script, MAX_IPXE_SCRIPT_LEN) + 1` before it's used in the `memcpy` operation.

**Testing**: This fix ensures the code compiles correctly and the script size is properly calculated when copying the extracted iPXE script data to the image buffer.