### PR TITLE
[json] Add JSON string extraction

### DIFF
--- a/src/include/ipxe/errfile.h
+++ b/src/include/ipxe/errfile.h
@@ -443,6 +443,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 #define ERRFILE_userdata_cmd ( ERRFILE_OTHER | 0x01000000 )
 #define ERRFILE_userdata     ( ERRFILE_OTHER | 0x01010000 )
 #define ERRFILE_imdsv2       ( ERRFILE_OTHER | 0x01030000 )
+#define ERRFILE_json         ( ERRFILE_OTHER | 0x01040000 )
 /** @} */
 
 #endif /* _IPXE_ERRFILE_H */

--- a/src/include/usr/json.h
+++ b/src/include/usr/json.h
@@ -1,0 +1,6 @@
+#ifndef _USR_JSON_H
+#define _USR_JSON_H
+
+extern int json_extract_string(char *json, char* key, char** output);
+
+#endif /* _USR_JSON_H */

--- a/src/tests/json_test.c
+++ b/src/tests/json_test.c
@@ -1,0 +1,111 @@
+FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+/** @file
+ *
+ * JSON string extraction tests
+ *
+ */
+
+/* Forcibly enable assertions */
+#undef NDEBUG
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <usr/json.h>
+#include <ipxe/test.h>
+
+/** A JSON extraction test */
+struct json_test {
+    /** Input JSON string */
+    const char *json;
+    /** Key to extract */
+    const char *key;
+    /** Expected output */
+    const char *expected;
+    /** Expected return code */
+    int expected_rc;
+};
+
+/** Define a JSON test */
+#define JSON_TEST(_name, _json, _key, _expected, _rc) \
+    static struct json_test _name = { \
+        .json = _json, \
+        .key = _key, \
+        .expected = _expected, \
+        .expected_rc = _rc, \
+    }
+
+/** AWS credentials response test (sanitized) */
+JSON_TEST ( aws_creds_test,
+    "{\n"
+    "  \"Code\" : \"Success\",\n"
+    "  \"LastUpdated\" : \"2025-06-19T20:56:49Z\",\n"
+    "  \"Type\" : \"AWS-HMAC\",\n"
+    "  \"AccessKeyId\" : \"ASIAEXAMPLEACCESSKEY\",\n"
+    "  \"SecretAccessKey\" : \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\",\n"
+    "  \"Token\" : \"IQoJb3JpZ2luX2V4AMEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLE"
+    "TOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXA"
+    "MPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKE"
+    "NEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLETOKENEXAMPLET"
+    "OKENEXAMPLETOKENEXAMPLETOKENEXAMPLE==\",\n"
+    "  \"Expiration\" : \"2025-06-20T03:31:27Z\"\n"
+    "}",
+    "AccessKeyId",
+    "ASIAEXAMPLEACCESSKEY",
+    0 );
+
+/** AWS secrets manager test */
+JSON_TEST ( aws_secret_test,
+    "{\"SecretString\":\"{\\\"password\\\":\\\"my-secure-password\\\"}\"}",
+    "SecretString",
+    "{\"password\":\"my-secure-password\"}",
+    0 );
+
+/** Escaped characters test */
+JSON_TEST ( escaped_chars_test,
+    "{\"value\":\"escaped\\\"quote and \\\\backslash\"}",
+    "value",
+    "escaped\"quote and \\backslash",
+    0 );
+
+/**
+ * Report a JSON extraction test result
+ *
+ * @v test      JSON test
+ * @v file      Test code file
+ * @v line      Test code line
+ */
+static void json_extract_okx ( struct json_test *test, const char *file,
+                             unsigned int line ) {
+    char *output = NULL;
+    int rc;
+
+    rc = json_extract_string ( ( char * ) test->json, 
+                             ( char * ) test->key, &output );
+    
+    okx ( rc == test->expected_rc, file, line );
+    
+    if ( rc == 0 ) {
+        okx ( strcmp ( output, test->expected ) == 0, file, line );
+    }
+
+    free ( output );
+}
+#define json_extract_ok( test ) json_extract_okx ( test, __FILE__, __LINE__ )
+
+/**
+ * Perform JSON extraction self-tests
+ *
+ */
+static void json_test_exec ( void ) {
+    json_extract_ok ( &aws_creds_test );
+    json_extract_ok ( &aws_secret_test );
+    json_extract_ok ( &escaped_chars_test );
+}
+
+/** JSON extraction self-test */
+struct self_test json_test __self_test = {
+    .name = "json",
+    .exec = json_test_exec,
+};

--- a/src/usr/json.c
+++ b/src/usr/json.c
@@ -1,0 +1,148 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+/**
+ * Unescapes a JSON-escaped string by converting known escape sequences
+ * (`\\` and `\"`) to their literal characters. Unknown escape sequences
+ * are preserved as-is.
+ *
+ * @v escaped_string     Input JSON-escaped string
+ * @v unescaped_string   Pointer to receive a heap-allocated unescaped string
+ * @ret rc     0 on success, negative on error
+ *
+ * The caller is responsible for freeing the allocated memory.
+ */
+
+static int unescape_string(const char *escaped_string, char **unescaped_string) {
+    *unescaped_string = NULL;
+
+    size_t escaped_len = strlen(escaped_string);
+    char *unescaped_str = calloc(escaped_len + 1, sizeof(char));
+    if (unescaped_str == NULL) {
+        return -ENOMEM;
+    }
+
+    size_t j = 0;
+    for (size_t i = 0; i < escaped_len; i++) {
+        if (escaped_string[i] == '\\' && i + 1 < escaped_len) {
+            char next_char = escaped_string[i + 1];
+            if (next_char == '\\' || next_char == '"') {
+                /* Unescape: add the actual character and skip both */
+                unescaped_str[j++] = next_char;
+                /* Skip the next character since we processed it */
+                i++; 
+            } else {
+                /* Unknown escape: keep both characters */
+                unescaped_str[j++] = escaped_string[i];
+            }
+        } else {
+            /* Regular character or backslash at end of string */
+            unescaped_str[j++] = escaped_string[i];
+        }
+    }
+
+    *unescaped_string = unescaped_str;
+
+    return 0;
+}
+
+ /**
+ * Extracts a string value associated with a key from a JSON-encoded string.
+ *
+ * This function locates a key within a flat, well-formed JSON object string, extracts
+ * the string value associated with that key, and performs a single level of unescaping
+ * on the value (e.g., turning `\\` into `\`, `\"` into `"`, etc).
+ *
+ * Limitations:
+ * - Only works on flat JSON objects with simple `"key":"value"` pairs.
+ * - Only supports extracting values of type string (enclosed in double quotes).
+ * - Does not handle arrays, nested objects, or complex escape sequences like unicode.
+ * - Escaped quote detection is naive and only handles a single backslash escape (`\"`),
+ *   not sequences like `\\"`.
+ *
+ * @v json     JSON input string with one layer of escaping
+ * @v key      Key to find
+ * @v output   Pointer to receive a heap-allocated copy of the unescaped value string
+ * @ret rc     0 on success, negative on error
+ *
+ * The caller is responsible for freeing the allocated memory.
+ */
+int json_extract_string(char *json, char* key, char** output) {
+    char *search_string = NULL;
+    char *escaped_value = NULL;
+    char *unescaped_value = NULL;
+    int rc = 0;
+    *output = NULL;
+
+    /* Build search string: quoted key */
+    if (asprintf(&search_string, "\"%s\"", key) < 0) {
+        rc = -ENOMEM;
+        goto cleanup;
+    }
+
+    /* Find key start */
+    const char* key_start = strstr(json, search_string);
+    if (!key_start) {
+        rc = -ENOENT;
+        goto cleanup;
+    }
+
+    /* Find the colon after the key */
+    const char* colon = strchr(key_start + strlen(search_string), ':');
+    if (!colon) {
+        rc = -EINVAL;
+        goto cleanup;
+    }
+
+    /* Find the opening quote after the colon */
+    const char* quote = strchr(++colon, '"');
+    if (!quote) {
+        rc = -EINVAL;
+        goto cleanup;
+    }
+
+    /* The value starts one character after the opening quote */
+    const char* value_start = ++quote;
+
+    /* Find the closing quote */
+    char *value_end = strchr(value_start, '"');
+    if (!value_end) {
+        rc = -EINVAL;
+        goto cleanup;
+    }
+
+    /* If the quote is escaped (preceded by '\'), keep searching for the real string end */
+    while (*(value_end - 1) == '\\') {
+        value_end = strchr(value_end + 1, '"');
+        if (!value_end) {
+            rc = -EINVAL;
+            goto cleanup;
+        }
+    }
+
+    size_t value_len = value_end - value_start;
+
+    /* Allocate and copy escaped substring */
+    escaped_value = calloc(value_len + 1, sizeof(char));
+    if (!escaped_value) {
+        rc = -ENOMEM;
+        goto cleanup;
+    }
+    memcpy(escaped_value, value_start, value_len);
+
+    /* Unescape the extracted value to decode escaped characters */
+    rc = unescape_string(escaped_value, &unescaped_value);
+    if (rc < 0) {
+        goto cleanup;
+    }
+
+    *output = unescaped_value;
+
+cleanup:
+    free(search_string);
+    free(escaped_value);
+    return rc;
+}


### PR DESCRIPTION
This PR add JSON string extraction functionality to support parsing cloud provider metadata responses. The implementation handles flat JSON objects with simple key-value pairs and performs basic unescaping of JSON escape sequences. This is primarily needed for AWS credential and secrets manager integration where iPXE needs to extract specific string values from JSON responses. The parser is intentionally minimal.

This CR also includes self tests.