### PR TITLE
[json-params] Add special handling for JSON params in http_form_params

### DIFF
--- a/src/core/params.c
+++ b/src/core/params.c
@@ -154,9 +154,10 @@ struct parameter * add_parameter ( struct parameters *params,
 	/* Add to list of parameters */
 	list_add_tail ( &param->list, &params->entries );
 
-	DBGC ( params, "PARAMS \"%s\" added \"%s\"=\"%s\"%s%s\n",
+	DBGC ( params, "PARAMS \"%s\" added \"%s\"=\"%s\"%s%s%s\n",
 	       params->name, param->key, param->value,
 	       ( ( param->flags & PARAMETER_FORM ) ? " (form)" : "" ),
-	       ( ( param->flags & PARAMETER_HEADER ) ? " (header)" : "" ) );
+           ( ( param->flags & PARAMETER_HEADER ) ? " (header)" : "" ),
+           ( ( param->flags & PARAMETER_JSON ) ? " (json)" : "" ) );
 	return param;
 }

--- a/src/include/ipxe/params.h
+++ b/src/include/ipxe/params.h
@@ -42,6 +42,9 @@ struct parameter {
 /** Request parameter is a header parameter */
 #define PARAMETER_HEADER 0x0002
 
+/** Request parameter is a JSON parameter */
+#define PARAMETER_JSON 0x0004
+
 /**
  * Increment request parameter list reference count
  *

--- a/src/net/tcp/httpcore.c
+++ b/src/net/tcp/httpcore.c
@@ -1894,9 +1894,16 @@ static size_t http_form_params ( struct parameters *params, char *buf,
 	len = 0;
 	for_each_param ( param, params ) {
 
-		/* Skip non-form parameters */
-		if ( ! ( param->flags & PARAMETER_FORM ) )
-			continue;
+		/* For JSON parameters, just return the key as-is. This
+		*  bypasses normal form encoding entirely.
+		*/
+		/* TODO: Refactor to handle JSON parameters in a separate function */
+		if ( param->flags & PARAMETER_JSON ) {
+            return ssnprintf(buf, remaining, "%s", param->key);
+        } else if ( ! ( param->flags & PARAMETER_FORM ) ) {
+            /* Skip non-form parameters */
+            continue; 
+        }
 
 		/* Add the "&", if applicable */
 		if ( len ) {


### PR DESCRIPTION
Previously, all parameters were encoded as form data (key=value&key2=value2 format with URI encoding). This doesn't work for JSON payloads which need to be sent as raw JSON strings.

Added check for PARAMETER_JSON flag:
- Form parameters: encoded as "key1=value1&key2=value2" with URI encoding
- JSON parameters: return just the key as-is (key contains the full JSON)

This is a temporary solution - JSON handling should be moved to a separate function in the future.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
