### PR TITLE
[content-type-headers] Allow Content-Type header override in HTTP requests

### DIFF
--- a/src/net/tcp/httpcore.c
+++ b/src/net/tcp/httpcore.c
@@ -1003,6 +1003,19 @@ static int http_format_content_type ( struct http_transaction *http,
 				      char *buf, size_t len ) {
 
 	/* Construct content type, if applicable */
+	/* If there's already a Content-Type header, do nothing  */
+	/* TODO: Refactor to be cleaner */
+	struct parameter *param;
+    if (http->uri->params) {
+        for_each_param(param, http->uri->params) {
+            if ((param->flags & PARAMETER_HEADER) && 
+                strcmp(param->key, "Content-Type") == 0) {
+                return 0;
+            }
+        }
+    }
+
+	/* Construct content type, if applicable */
 	if ( http->request.content.type ) {
 		return snprintf ( buf, len, "%s", http->request.content.type );
 	} else {


### PR DESCRIPTION
Modified http_format_content_type to check for existing Content-Type headers in URI parameters before applying the default content type. This prevents automatic content-type generation when a custom Content-Type header has been explicitly set.

This enables setting custom content types like "application/x-amz-json-1.1" for AWS API requests without being overridden by iPXE's default behavior.
