### PR TITLE
[imdsv2-refactor] Refactor IMDSv2 utilities and improve error handling

### DIFF
--- a/src/include/usr/imdsv2.h
+++ b/src/include/usr/imdsv2.h
@@ -1,6 +1,8 @@
 #ifndef _USR_IMDSV2_H
 #define _USR_IMDSV2_H
 
+#include <ipxe/image.h>
+
 /** @file
  *
  * AWS Instance Metadata Service (IMDSv2) helper commands
@@ -9,10 +11,10 @@
 
 extern int get_image_data ( struct image *image, char **buffer );
 extern int url_concat ( const char *base_url, const char *path, char **url );
-extern int get_imdsv2_token ( char **token, const char *base_url );
+extern int download_and_get_string ( struct uri *uri, char **result );
+extern int get_imdsv2_token ( const char *base_url, char **token );
 extern int get_imdsv2_metadata ( char *token, const char *base_url, char *metadata_path, char **response );
-extern int get_imds_metadata_base_url ( int use_ipv6, const char **base_url );
-extern int parse_imdsv2_credentials_response ( char *credentials, char *key, char **parsed_val );
+extern int get_imdsv2_metadata_base_url ( int use_ipv6, const char **base_url );
 
 #define IMDSV2_IPV4_METADATA_BASE_URL "http://169.254.169.254/latest/"
 #define IMDSV2_IPV6_METADATA_BASE_URL "http://[fd00:ec2::254]/latest/"

--- a/src/usr/imdsv2.c
+++ b/src/usr/imdsv2.c
@@ -56,65 +56,6 @@ int url_concat ( const char *base_url, const char *path, char **url ) {
 }
 
 /**
- * Parses a specific credential value from an IMDSv2 credentials response.
- *
- * This function extracts the value associated with a given key from a JSON-formatted
- * credentials response obtained from IMDSv2. It is NOT a general-purpose JSON parser.
- *
- * @v credentials	The JSON-formatted credentials response string.
- * @v key			The key for the credential value to extract.
- * @v parsed_val	Pointer to the extracted value (newly allocated). Unmodified on error.
- * @ret rc			Return status code
- *
- * The caller is responsible for freeing the memory allocated for the returned string.
- */
-int parse_imdsv2_credentials_response ( char *credentials, char *key, char **parsed_val ) {
-	/* +3 for quotes and null terminator */
-	char key_with_quotes[strlen ( key ) + 3];
-	snprintf ( key_with_quotes, sizeof ( key_with_quotes ), "\"%s\"", key );
-
-	/* Find the key */
-	const char *key_start = strstr ( credentials, key_with_quotes );
-	if ( ! key_start ) {
-		return -1;
-	}
-
-	/* Find the colon, skipping whitespace */
-	const char *colon = strchr ( key_start + strlen ( key_with_quotes ), ':' );
-	if ( ! colon ) {
-		return -1;
-	}
-
-	/* Find the opening quote, skipping whitespace */
-	const char *quote = strchr ( ++colon, '"' );
-	if ( ! quote ) {
-		return -1;
-	}
-
-	/* Value starts immediately after the opening quote */
-	const char *value_start = ++quote;
-
-	const char *value_end = strchr ( value_start, '"' );
-
-	const size_t value_length = value_end - value_start;
-	const size_t value_buffer_size = value_length + 1;
-
-	char *value = ( char * ) malloc ( value_buffer_size );
-	if ( ! value ) {
-		return -ENOMEM;
-	}
-
-	/* Fill the memory location with /0's */
-	memset ( value, 0, sizeof ( char ) * value_buffer_size );
-
-	strncpy ( value, value_start, value_length );
-
-	*parsed_val = value;
-
-	return 0;
-}
-
-/**
  * Copy image data to a buffer
  *
  * @v image		Image to read
@@ -122,6 +63,9 @@ int parse_imdsv2_credentials_response ( char *credentials, char *key, char **par
  * @ret rc      Return status code
  */
 int get_image_data ( struct image *image, char **buffer ) {
+	/* Initialize output parameter */
+	*buffer = NULL;
+
 	size_t offset = 0;
 
 	/* Allocate a buffer to hold the data */
@@ -139,19 +83,49 @@ int get_image_data ( struct image *image, char **buffer ) {
 	return 0;
 }
 
+int download_and_get_string ( struct uri *uri, char **result ) {
+	int rc;
+	struct image *image = NULL;
+
+	/* Initialize output parameter */
+	*result = NULL;
+
+	/* Get our own reference */
+	uri = uri_get ( uri );
+
+	/* Download content into image */
+	rc = imgdownload ( uri, 0, &image );
+	if ( rc != 0 )
+		goto err_download;
+
+	/* Convert image data to string */
+	rc = get_image_data ( image, result );
+	if ( rc != 0 )
+		goto err_conversion;
+
+	image_put ( image );
+	return 0;
+
+err_conversion:
+	image_put ( image );
+err_download:
+	return rc;
+}
+
 /**
  * Get IMDSv2 session token
  *
  * @v token           Pointer to store the token string
- * @v base_url   The AWS IMDS ipv4 or ipv6 base url
+ * @v base_url        The AWS IMDS ipv4 or ipv6 base url
  * @ret rc            Return status code
  */
-int get_imdsv2_token ( char **token, const char *base_url ) {
+int get_imdsv2_token ( const char *base_url, char **token ) {
 	char *uri_string = NULL;
 	struct uri *uri = NULL;
-	;
-	struct image *image = NULL;
 	int rc;
+
+	/* Initialize token to NULL */
+	*token = NULL;
 
 	/* Build IMDSv2 api token URI */
 	rc = url_concat ( base_url, "api/token", &uri_string );
@@ -159,42 +133,29 @@ int get_imdsv2_token ( char **token, const char *base_url ) {
 		goto err_url_concat;
 	}
 
-	/* Initialize token to NULL */
-	*token = NULL;
-
 	/* Parse the URI string */
 	uri = parse_uri ( uri_string );
-	if ( ! uri ) {
+	if ( uri == NULL ) {
 		rc = -ENOMEM;
-		goto err_uri;
+		goto err_uri_parse;
 	}
 
-	/* Set the HTTP method */
 	uri->method = &http_put;
-	/* Set aws token ttl */
 	uri->aws_token_ttl = AWS_TOKEN_TTL;
 
-	/* Get token and store it in an image */
-	rc = imgdownload ( uri, 0, &image );
+	rc = download_and_get_string ( uri, token );
 	if ( rc != 0 )
-		goto err_token_download;
+		goto err_download;
 
-	/* Get the image data as string */
-	rc = get_image_data ( image, token );
-	if ( rc != 0 )
-		goto err_token_read;
-
-	free ( uri );
-	free ( image );
 	free ( uri_string );
-	return 0;
-err_token_read:
-	image_put ( image );
-err_token_download:
 	uri_put ( uri );
-err_uri:
-err_url_concat:
+	return 0;
+
+err_download:
+	uri_put ( uri );
+err_uri_parse:
 	free ( uri_string );
+err_url_concat:
 	return rc;
 }
 
@@ -209,51 +170,40 @@ err_url_concat:
 int get_imdsv2_metadata ( char *token, const char *base_url, char *metadata_path, char **response ) {
 	char *uri_string = NULL;
 	struct uri *uri = NULL;
-	struct image *image = NULL;
 	int rc;
+
+	/* Initialize response to NULL */
+	*response = NULL;
 
 	/* Build IMDSv2 metadata URI */
 	rc = url_concat ( base_url, metadata_path, &uri_string );
 	if ( rc != 0 ) {
 		goto err_url_concat;
 	}
-
-	/* Initialize reponse to NULL */
-	*response = NULL;
-
 	/* Parse the URI string */
 	uri = parse_uri ( uri_string );
-	if ( ! uri ) {
+	if ( uri == NULL ) {
 		rc = -ENOMEM;
-		goto err_uri;
+		goto err_uri_parse;
 	}
 
-	/* Set the HTTP method */
 	uri->method = &http_get;
-	/* Set AWS IMDSv2 token */
 	uri->aws_token = token;
 
-	/* Get response and store it in an image */
-	rc = imgdownload ( uri, 0, &image );
-	if ( rc != 0 )
-		goto err_metadata_download;
+	rc = download_and_get_string ( uri, response );
+	if ( rc != 0 ) {
+		goto err_download;
+	}
 
-	/* Get the image data as string */
-	rc = get_image_data ( image, response );
-	if ( rc != 0 )
-		goto err_metadata_read;
-
-	free ( uri );
-	free ( image );
 	free ( uri_string );
-	return 0;
-err_metadata_read:
-	image_put ( image );
-err_metadata_download:
 	uri_put ( uri );
-err_uri:
-err_url_concat:
+	return 0;
+
+err_download:
+	uri_put ( uri );
+err_uri_parse:
 	free ( uri_string );
+err_url_concat:
 	return rc;
 }
 
@@ -266,7 +216,7 @@ err_url_concat:
  *
  * @ret rc      Return status code
  */
-int get_imds_metadata_base_url ( int use_ipv6, const char **base_url ) {
+int get_imdsv2_metadata_base_url ( int use_ipv6, const char **base_url ) {
 	if ( use_ipv6 ) {
 		*base_url = IMDSV2_IPV6_METADATA_BASE_URL;
 	} else {

--- a/src/usr/userdata.c
+++ b/src/usr/userdata.c
@@ -328,7 +328,7 @@ err_buffer:
 /**
  * Get user data and store it in an image
  *
- * @v use_ipv6  Boolean flag to determine whether to use IPv6 (true) or IPv4 (false)
+ * @v use_ipv6   Boolean flag to determine whether to use IPv6 (true) or IPv4 (false)
  * @v image		Image to fill in
  * @ret rc		Return status code
  */
@@ -339,12 +339,12 @@ int get_userdata ( int use_ipv6, struct image **image ) {
 	char *token = NULL;
 	int rc;
 
-	rc = get_imds_metadata_base_url ( use_ipv6, &base_url );
+	rc = get_imdsv2_metadata_base_url ( use_ipv6, &base_url );
 	if ( rc != 0 )
 		goto err_base_url;
 
 	/* Get IMDSv2 session token */
-	rc = get_imdsv2_token ( &token, base_url );
+	rc = get_imdsv2_token ( base_url, &token );
 	if ( rc != 0 )
 		goto err_token;
 


### PR DESCRIPTION
Major changes to imdsv2.c:
- Add download_and_get_string() helper function to consolidate common download-and-convert-to-string pattern used by multiple functions
- Remove parse_imdsv2_credentials_response() (handled in json.c)
- Refactor get_imdsv2_token() and get_imdsv2_metadata() to use new helper, improving error handling and reducing code duplication
- Change get_imdsv2_token() parameter order for consistency
- Rename get_imds_metadata_base_url() to get_imdsv2_metadata_base_url()
- Add proper output parameter initialization in get_image_data()